### PR TITLE
Adds a limit to the number of items you can hold

### DIFF
--- a/contracts/src/cards/actions.cairo
+++ b/contracts/src/cards/actions.cairo
@@ -141,7 +141,7 @@ fn stat_meets_threshold(
                 return false;
             }
             let value = get!(ctx.world, (stat_id, game_id), ValueInGame).value;
-            value > threshold
+            value >= threshold
         },
         Option::None => {
             true
@@ -157,9 +157,9 @@ fn polar_stat_meets_threshold(
         Option::Some((threshold, is_negative)) => {
             let value = get!(ctx.world, (stat_id, game_id), ValueInGame).value;
             if is_negative && !reverse || !is_negative && reverse {
-                value < POLAR_STAT_MIDPOINT - threshold
+                value <= POLAR_STAT_MIDPOINT - threshold
             } else {
-                value > POLAR_STAT_MIDPOINT + threshold
+                value >= POLAR_STAT_MIDPOINT + threshold
             }
         },
         Option::None => {

--- a/contracts/src/constants.cairo
+++ b/contracts/src/constants.cairo
@@ -1,14 +1,16 @@
 const INITIAL_BARRIERS: u32 = 3;
 const CHAOS_PER_FORAGE: u32 = 3;
+const ITEM_LIMIT: u32 = 7;
 
 // ensure these dont collide with card ids
 const CHAOS_STAT: u128 = 10000;
 const POWER_STAT: u128 = 10001;
 const BARRIERS_STAT: u128 = 10002;
+const ITEMS_HELD: u128 = 10003;
 
 // this is zero for stats that can go +/-
 const POLAR_STAT_MIDPOINT: u32 = 2_147_483_647;
 
 // polar stats
-const HOTCOLD_STAT: u128 = 10003;
-const LIGHTDARK_STAT: u128 = 10004;
+const HOTCOLD_STAT: u128 = 10004;
+const LIGHTDARK_STAT: u128 = 10005;

--- a/contracts/src/systems/forage.cairo
+++ b/contracts/src/systems/forage.cairo
@@ -4,11 +4,11 @@ mod Forage {
     use box::BoxTrait;
     use dojo::world::Context;
 
-    use spellcrafter::constants::{CHAOS_STAT, CHAOS_PER_FORAGE};
+    use spellcrafter::constants::{CHAOS_STAT, ITEMS_HELD, CHAOS_PER_FORAGE, ITEM_LIMIT};
     use spellcrafter::components::{Owner, ValueInGame};
     use spellcrafter::utils::assertions::{assert_caller_is_owner, assert_is_alive};
     use spellcrafter::cards::selection::random_card_from_region;
-    use spellcrafter::cards::actions::increase_stat;
+    use spellcrafter::cards::actions::{increase_stat, stat_meets_threshold};
     use spellcrafter::types::Region;
 
     // In the context of a particular game, forage in a given region
@@ -16,6 +16,7 @@ mod Forage {
     fn execute(ctx: Context, game_id: u128, region: Region) -> u128 {
         assert_caller_is_owner(ctx, game_id);
         assert_is_alive(ctx, game_id);
+        assert(!stat_meets_threshold(ctx, game_id, ITEMS_HELD, Option::Some((ITEM_LIMIT, false))), 'Too many items held');
         
         // TODO This is not simulation safe. Ok for quick protyping only
         let tx_info = starknet::get_tx_info().unbox();
@@ -25,13 +26,10 @@ mod Forage {
 
         // increase chaos by a fixed amount. In the future this will be a function of time
         increase_stat(ctx, game_id, CHAOS_STAT, CHAOS_PER_FORAGE);
-
-        let card = get!(ctx.world, (card_id, game_id), ValueInGame);
-        set!(ctx.world, ValueInGame {
-            entity_id: card.entity_id,
-            game_id: card.game_id,
-            value: card.value + 1
-        });
+        // increase the number of that card
+        increase_stat(ctx, game_id, card_id, 1);
+        // increase the total number of items held
+        increase_stat(ctx, game_id, ITEMS_HELD, 1);
 
         return card_id;
     }
@@ -50,6 +48,8 @@ mod tests {
     use spellcrafter::types::Region;
     use spellcrafter::utils::testing::initialize_world;
     use spellcrafter::components::{Owner, ValueInGame};
+    use spellcrafter::constants::{ITEMS_HELD, ITEM_LIMIT};
+
 
     #[test]
     #[available_gas(300000000000)]
@@ -64,6 +64,35 @@ mod tests {
         // post conditions
         let card = get!(world, (card_id, game_id), ValueInGame);
         assert(card.value == 1, 'failed to add ingredient');
+    }
+
+    #[test]
+    #[available_gas(300000000000)]
+    #[should_panic(expected: ('Too many items held', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED') )]
+    fn cannot_exceed_max_items() {
+        let world = initialize_world();        
+        let result = world.execute('NewGame', array![]);
+        let game_id: u128 = (*result[0]).try_into().unwrap();
+
+        // post conditions
+        let items = get!(world, (ITEMS_HELD, game_id), ValueInGame).value;
+        assert(items == 0, 'not initially no items');
+
+        let mut i = 0;
+        loop {
+            if i >= ITEM_LIMIT {
+                break;
+            }
+            world.execute('Forage', build_calldata(game_id, Region::Forest));
+            i += 1;
+        };
+
+        // post conditions
+        let items = get!(world, (ITEMS_HELD, game_id), ValueInGame).value;
+        assert(items == ITEM_LIMIT, 'not expected n_items');
+
+        // should fail
+        world.execute('Forage', build_calldata(game_id, Region::Forest));
     }
 
     fn build_calldata(game_id: u128, region: Region) -> Array<felt252> {

--- a/contracts/src/systems/forage.cairo
+++ b/contracts/src/systems/forage.cairo
@@ -74,7 +74,7 @@ mod tests {
         let result = world.execute('NewGame', array![]);
         let game_id: u128 = (*result[0]).try_into().unwrap();
 
-        // post conditions
+        // pre conditions
         let items = get!(world, (ITEMS_HELD, game_id), ValueInGame).value;
         assert(items == 0, 'not initially no items');
 


### PR DESCRIPTION
Now a game keeps track of the total number of items you have foraged and and won't allow this to exceed a value (currently 7). This prevents the gameplay style where you just got and forage for like every card before playing any.